### PR TITLE
change dockerfile node version

### DIFF
--- a/result/Dockerfile
+++ b/result/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:18-slim
 
 # add curl for healthcheck
 # add wait-for-it to delay start


### PR DESCRIPTION
Currently the `node:10-slim` fails, updating to 18 fixes the demo. 
You can see the working version here: https://github.com/aabedraba/quickstart/pull/1